### PR TITLE
feat: Added Older Mac installation instructions

### DIFF
--- a/Unit 0 - Installation of Julia, Jupyter and IJulia.ipynb
+++ b/Unit 0 - Installation of Julia, Jupyter and IJulia.ipynb
@@ -27,6 +27,8 @@
     "\n",
     "Julia installation is pretty straightforward, whether using precompiled binaries or compiling from source. Download and install Julia by following the instructions at [https://julialang.org/downloads/].\n",
     "\n",
+    "> ⚠️ **Older Mac users**: Installing Julia might be troublesome due to deprecated compilers. In case of errors during installation, it might be worth trying to install it via [MacPorts](https://ports.macports.org/port/julia/). After MacPorts [installation](https://www.macports.org/install.php/), Julia can be installed just by `sudo port install julia`.\n",
+    "\n",
     "It could be worth to also install jupyter in a local environment to perform some test. This can be done by executing the following command, if you do not have it already installed."
    ]
   },


### PR DESCRIPTION
Older Mac will get installation problems because of some Rust conflicts. Installing through MacPorts should work just fine for these older Macs.